### PR TITLE
hotfix: login success redirect is an exception that shouldnt be caught

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -11,19 +11,16 @@ if (!env.MENSA_API_URL) {
 }
 
 export const handle: Handle = async ({ event, resolve }) => {
-	// only check cookie existence for non-api routes for performance reasons
-	if (!event.route?.id?.includes('api')) {
-		const jwt = event.cookies.get('jwt');
+	const jwt = event.cookies.get('jwt');
 
-		if (!jwt && event.url.pathname !== '/') {
-			console.log('redirecting to /');
-			return Response.redirect(new URL('/', event.url));
-		}
+	if (!jwt && event.url.pathname !== '/') {
+		console.log('redirecting to /');
+		return Response.redirect(new URL('/', event.url));
+	}
 
-		if (jwt && event.url.pathname === '/') {
-			console.log('redirecting to /dashboard');
-			return Response.redirect(new URL('/dashboard', event.url));
-		}
+	if (jwt && event.url.pathname === '/') {
+		console.log('redirecting to /dashboard');
+		return Response.redirect(new URL('/dashboard', event.url));
 	}
 
 	return resolve(event);

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -54,6 +54,8 @@ export const actions: Actions = {
 				return fail(500, {
 					message: 'CampusUnbloat ist nicht verfügbar.'
 				});
+			} else {
+				throw error;
 			}
 		}
 	}


### PR DESCRIPTION
Will merge immediately since it somewhat breaks the login and just reverts two small changes (hooks.ts reverts are unrelated but had downsides)