### PR TITLE
Fix android PWA cookie issue

### DIFF
--- a/src/lib/TSHelpers/DateHelper.ts
+++ b/src/lib/TSHelpers/DateHelper.ts
@@ -54,12 +54,6 @@ function getDiffInDays(date1: Date, date2: Date): number {
 	return Math.round(diffInDays);
 }
 
-export function inThirteenWeeks() {
-	const date = new Date();
-	date.setDate(date.getDate() + 13 * 7); // 13 weeks ≙ 1 semester
-	return date;
-}
-
 export function dateIsToday(date: Date): boolean {
 	const today = new Date();
 	return (

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,7 +1,6 @@
 import { fail, isRedirect, redirect } from '@sveltejs/kit';
 import type { Actions } from './$types';
 import { env } from '$env/dynamic/private';
-import { inThirteenWeeks } from '$lib/TSHelpers/DateHelper';
 
 export const actions: Actions = {
 	login: async ({ cookies, request }) => {
@@ -38,18 +37,18 @@ export const actions: Actions = {
 
 				cookies.set('jwt', loginResponse.token, {
 					path: '/',
-					sameSite: 'strict',
+					sameSite: 'lax',
 					httpOnly: true,
 					secure: process.env.NODE_ENV === 'production',
-					expires: inThirteenWeeks()
+					maxAge: 60 * 60 * 24 * 7 * 13
 				});
 
 				cookies.set('user_basic', JSON.stringify(loginResponse.user), {
 					path: '/',
-					sameSite: 'strict',
+					sameSite: 'lax',
 					httpOnly: true,
 					secure: process.env.NODE_ENV === 'production',
-					expires: inThirteenWeeks()
+					maxAge: 60 * 60 * 24 * 7 * 13
 				});
 
 				throw redirect(303, '/dashboard');

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -1,5 +1,4 @@
 import { env } from '$env/dynamic/private';
-import { inThirteenWeeks } from '$lib/TSHelpers/DateHelper';
 import { error } from '@sveltejs/kit';
 
 export async function load({ cookies }) {
@@ -22,17 +21,17 @@ export async function load({ cookies }) {
 		console.log('updating jwt cookie');
 		cookies.set('jwt', loginResponse.token, {
 			path: '/',
-			sameSite: 'strict',
+			sameSite: 'lax',
 			httpOnly: true,
 			secure: process.env.NODE_ENV === 'production',
-			expires: inThirteenWeeks()
+			maxAge: 60 * 60 * 24 * 7 * 13
 		});
 		cookies.set('user_basic', JSON.stringify(loginResponse.user), {
 			path: '/',
-			sameSite: 'strict',
+			sameSite: 'lax',
 			httpOnly: true,
 			secure: process.env.NODE_ENV === 'production',
-			expires: inThirteenWeeks()
+			maxAge: 60 * 60 * 24 * 7 * 13
 		});
 	}
 

--- a/src/routes/logout/+server.ts
+++ b/src/routes/logout/+server.ts
@@ -4,7 +4,7 @@ export async function POST({ cookies }) {
 	// Unset the cookie by setting its expiry date to a date in the past
 	cookies.set('jwt', '', {
 		path: '/',
-		sameSite: 'strict',
+		sameSite: 'lax',
 		httpOnly: true,
 		secure: process.env.NODE_ENV === 'production'
 	});


### PR DESCRIPTION
cookie sameSite=strict doesn’t work in android PWAs, likely because it starts them internally after a top level navigation, which violates strict