### PR TITLE
add h-full to tiles

### DIFF
--- a/src/lib/DashboardTile.svelte
+++ b/src/lib/DashboardTile.svelte
@@ -13,7 +13,7 @@
 	on:click={() => dispatch('click')}
 	class="{clickable && ready
 		? ''
-		: 'pointer-events-none'} bg-[#ddb8c1] dark:bg-[#3b1725] flex flex-col items-center w-full sm:w-96 rounded-xl p-4 pt-2 pb-3 space-y-1"
+		: 'pointer-events-none'} h-full bg-[#ddb8c1] dark:bg-[#3b1725] flex flex-col items-center w-full sm:w-96 rounded-xl p-4 pt-2 pb-3 space-y-1"
 >
 	<div class="flex items-center w-full">
 		{#if clickable}


### PR DESCRIPTION
Needed as they aren't directly in the display:grid anymore, the portal divs are inbetween, so tiles must use full portal div height