### PR TITLE
fix calendar selector vertical align

### DIFF
--- a/src/lib/Calendar/CalendarSelector.svelte
+++ b/src/lib/Calendar/CalendarSelector.svelte
@@ -39,7 +39,7 @@
 	}
 </script>
 
-<div class="flex flex-row mb-2 space-x-1 w-full justify-between">
+<div class="flex flex-row mb-2 space-x-1 w-full justify-between items-center">
 	<TileInteractiveElementWrapper>
 		<button
 			on:click={() => handleDaySelection(false)}


### PR DESCRIPTION
the buttons weren't centered vertically, causing them to be slightly too high